### PR TITLE
Package app for module execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# btc_monitor
+# BitMine BTC Monitor
+
+A lightweight Flask dashboard that displays the latest Bitcoin (BTC) spot
+price alongside BitMine's treasury profile. The page highlights potential
+arbitrage opportunities between BitMine's internal benchmark and the live
+market, and estimates how much of a "true believer" the company is on a
+1–5 scale based on their treasury allocation.
+
+## Features
+
+- Fetches the latest BTC/USD price from the Coindesk public API with a
+  graceful offline fallback.
+- Shows the market value of BitMine's disclosed holdings.
+- Flags arbitrage opportunities when BitMine's benchmark diverges
+  materially from the market price.
+- Scores BitMine's conviction in bitcoin using a transparent heuristic.
+- Provides both a web dashboard and a JSON API at `/api/bitmine`.
+
+## Run it locally
+
+These commands clone the repository, install the dependencies, and launch
+an HTTP server listening on <http://localhost:8000>.
+
+```bash
+# Clone the project from GitHub and move into the directory
+git clone https://github.com/<your-account>/btc_monitor.git
+cd btc_monitor
+
+# Create an isolated Python environment and install dependencies
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Start the web dashboard
+python -m btc_monitor
+```
+
+After the server starts, open <http://localhost:8000> in a browser to view
+the dashboard. The JSON representation of the same data lives at
+<http://localhost:8000/api/bitmine>.
+
+To stop the server press `Ctrl+C` in the terminal where it is running.
+
+## Alternative entry points
+
+- **Flask CLI:** `flask --app btc_monitor.app run --port 8000 --debug`
+- **Gunicorn (production-style):** `gunicorn --bind 0.0.0.0:8000 btc_monitor:app`
+
+## Testing
+
+To ensure the application has no syntax errors you can run:
+
+```bash
+python -m compileall .
+```
+
+The command compiles all Python files and fails if there are syntax
+issues.

--- a/btc_monitor/__init__.py
+++ b/btc_monitor/__init__.py
@@ -1,0 +1,5 @@
+"""BitMine BTC monitoring dashboard package."""
+
+from .app import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/btc_monitor/__main__.py
+++ b/btc_monitor/__main__.py
@@ -1,0 +1,12 @@
+"""CLI entry point for running the BitMine BTC monitor."""
+
+from . import create_app
+
+
+def main() -> None:
+    app = create_app()
+    app.run(host="0.0.0.0", port=8000, debug=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/btc_monitor/app.py
+++ b/btc_monitor/app.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from flask import Flask, jsonify, render_template
+
+from .bitmine import BITMINE_PROFILE, evaluate_arbitrage, evaluate_true_believer
+from .market import format_currency, get_btc_price
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__, template_folder="templates", static_folder="static")
+
+    @app.route("/")
+    def dashboard():
+        price, source = get_btc_price()
+        arbitrage = evaluate_arbitrage(price, BITMINE_PROFILE)
+        believer = evaluate_true_believer(BITMINE_PROFILE, price)
+        holdings_value = BITMINE_PROFILE.btc_holdings * price
+
+        return render_template(
+            "index.html",
+            price=price,
+            price_display=format_currency(price),
+            price_source=source,
+            bitmine=BITMINE_PROFILE,
+            holdings_value=format_currency(holdings_value),
+            arbitrage=arbitrage,
+            believer=believer,
+            format_currency=format_currency,
+        )
+
+    @app.route("/api/bitmine")
+    def bitmine_api():
+        price, source = get_btc_price()
+        arbitrage = evaluate_arbitrage(price, BITMINE_PROFILE)
+        believer = evaluate_true_believer(BITMINE_PROFILE, price)
+
+        return jsonify(
+            {
+                "price_usd": price,
+                "price_source": source,
+                "bitmine": {
+                    "name": BITMINE_PROFILE.name,
+                    "btc_holdings": BITMINE_PROFILE.btc_holdings,
+                    "internal_price_per_btc": BITMINE_PROFILE.internal_price_per_btc,
+                    "usd_liquidity": BITMINE_PROFILE.usd_liquidity,
+                    "strategic_notes": BITMINE_PROFILE.strategic_notes,
+                },
+                "holdings_value_usd": BITMINE_PROFILE.btc_holdings * price,
+                "arbitrage": arbitrage,
+                "true_believer": believer,
+            }
+        )
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/btc_monitor/bitmine.py
+++ b/btc_monitor/bitmine.py
@@ -1,0 +1,118 @@
+"""Domain data and heuristics about BitMine's Bitcoin treasury."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class BitmineProfile:
+    """Represents the publicly disclosed holdings and pricing strategy."""
+
+    name: str
+    btc_holdings: float
+    internal_price_per_btc: float
+    usd_liquidity: float
+    strategic_notes: str
+
+
+BITMINE_PROFILE = BitmineProfile(
+    name="BitMine",
+    btc_holdings=1250.0,
+    internal_price_per_btc=54000.0,
+    usd_liquidity=35_000_000.0,
+    strategic_notes=(
+        "BitMine focuses on long-term custody while opportunistically "
+        "selling tranches when the market price materially exceeds their "
+        "internal valuation benchmark."
+    ),
+)
+
+
+def evaluate_arbitrage(market_price: float, profile: BitmineProfile) -> Dict[str, str]:
+    """Return a description of whether an arbitrage trade exists.
+
+    The function compares BitMine's internal sale price with the live
+    market price. If BitMine's internal price is lower, there is an
+    opportunity to purchase from BitMine and immediately sell on the
+    open market. Conversely, if BitMine is willing to buy above the
+    market rate it could be advantageous to sell to them.
+    """
+
+    difference = market_price - profile.internal_price_per_btc
+    if difference > 750:
+        status = "Buy from BitMine"
+        description = (
+            "BitMine's ask is lower than spot by ${:,.2f}. Buying from "
+            "them and selling on the market would lock in the spread."
+        ).format(difference)
+    elif difference < -750:
+        status = "Sell to BitMine"
+        description = (
+            "BitMine is paying ${:,.2f} above spot. Selling to them could "
+            "capture the premium."
+        ).format(-difference)
+    else:
+        status = "No clear arbitrage"
+        description = (
+            "BitMine's benchmark is roughly in line with the market. Any "
+            "spread under $750 would likely be consumed by fees and slippage."
+        )
+
+    return {
+        "status": status,
+        "description": description,
+        "spread": difference,
+    }
+
+
+def evaluate_true_believer(profile: BitmineProfile, market_price: float) -> Dict[str, object]:
+    """Score BitMine's conviction in bitcoin on a 1-5 scale.
+
+    The score uses a simple heuristic based on the proportion of the
+    company's treasury kept in BTC and whether they are accumulating
+    relative to their internal price target.
+    """
+
+    btc_value = profile.btc_holdings * market_price
+    total_assets = btc_value + profile.usd_liquidity
+    if total_assets == 0:
+        ratio = 0
+    else:
+        ratio = btc_value / total_assets
+
+    if ratio >= 0.75:
+        score = 5
+        rationale = "The majority of treasury assets are held in bitcoin."
+    elif ratio >= 0.6:
+        score = 4
+        rationale = "Bitcoin is the dominant allocation in the treasury."
+    elif ratio >= 0.4:
+        score = 3
+        rationale = "Holdings are balanced between bitcoin and cash."
+    elif ratio >= 0.2:
+        score = 2
+        rationale = "Cash holdings outweigh bitcoin, signalling caution."
+    else:
+        score = 1
+        rationale = "Bitcoin is a minor portion of the treasury."
+
+    if market_price <= profile.internal_price_per_btc * 0.97:
+        commentary = (
+            "BitMine is likely to accumulate below their internal valuation."
+        )
+    elif market_price >= profile.internal_price_per_btc * 1.03:
+        commentary = (
+            "BitMine may trim their position above the benchmark price."
+        )
+    else:
+        commentary = (
+            "BitMine appears content to maintain current exposure near fair value."
+        )
+
+    return {
+        "score": score,
+        "ratio": ratio,
+        "rationale": rationale,
+        "commentary": commentary,
+    }

--- a/btc_monitor/market.py
+++ b/btc_monitor/market.py
@@ -1,0 +1,50 @@
+"""Helpers for retrieving bitcoin market data."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Tuple
+
+import requests
+
+DEFAULT_PRICE = 56000.0
+API_URL = "https://api.coindesk.com/v1/bpi/currentprice/BTC.json"
+
+
+def get_btc_price() -> Tuple[float, str]:
+    """Fetch the current BTC price in USD.
+
+    The function tries to query the Coindesk API, but gracefully falls
+    back to a cached price when the network is unavailable.
+    """
+
+    try:
+        response = requests.get(API_URL, timeout=5)
+        response.raise_for_status()
+        payload = response.json()
+        rate = float(payload["bpi"]["USD"]["rate_float"])
+        time_updated = payload.get("time", {}).get("updatedISO", "")
+        source = f"Coindesk (updated {time_updated or 'recently'})"
+        return rate, source
+    except (requests.RequestException, KeyError, ValueError, TypeError, json.JSONDecodeError):
+        return DEFAULT_PRICE, "Fallback price (network unavailable)"
+
+
+def format_currency(value: float) -> str:
+    """Format a number as USD currency."""
+
+    return f"${value:,.2f}"
+
+
+def format_timestamp_iso(timestamp: str) -> str:
+    """Return a human friendly string for an ISO timestamp."""
+
+    if not timestamp:
+        return "N/A"
+
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return timestamp
+
+    return parsed.strftime("%Y-%m-%d %H:%M UTC")

--- a/btc_monitor/static/styles.css
+++ b/btc_monitor/static/styles.css
@@ -1,0 +1,102 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  background-color: #0d1117;
+  color: #e6edf3;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+}
+
+.page-header,
+.page-footer {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.page-header h1 {
+  margin-bottom: 0.5rem;
+  font-size: 2.25rem;
+}
+
+.subtitle {
+  margin: 0;
+  color: #7d8590;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+}
+
+.card.highlight {
+  border-color: #2f81f7;
+  box-shadow: 0 12px 30px rgba(47, 129, 247, 0.25);
+}
+
+.price {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0.5rem 0;
+}
+
+.details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 1.5rem 0 0;
+}
+
+.details dt {
+  font-weight: 500;
+  color: #9ea7b3;
+}
+
+.details dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.arbitrage-status {
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.spread {
+  margin-top: 1rem;
+  color: #9ea7b3;
+}
+
+.score {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #3fb950;
+  margin-bottom: 0.75rem;
+}
+
+.meta {
+  color: #7d8590;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .page-header h1 {
+    font-size: 1.75rem;
+  }
+}

--- a/btc_monitor/templates/index.html
+++ b/btc_monitor/templates/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>BitMine BTC Monitor</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>BitMine Bitcoin Treasury Dashboard</h1>
+      <p class="subtitle">Live comparison of market pricing vs. BitMine's internal benchmarks.</p>
+    </header>
+
+    <main class="grid">
+      <section class="card highlight">
+        <h2>Spot Price</h2>
+        <p class="price">{{ price_display }}</p>
+        <p class="meta">Source: {{ price_source }}</p>
+        <dl class="details">
+          <div>
+            <dt>BTC Holdings</dt>
+            <dd>{{ bitmine.btc_holdings }} BTC</dd>
+          </div>
+          <div>
+            <dt>Holdings Market Value</dt>
+            <dd>{{ holdings_value }}</dd>
+          </div>
+          <div>
+            <dt>Internal Benchmark</dt>
+            <dd>{{ format_currency(bitmine.internal_price_per_btc) }}</dd>
+          </div>
+          <div>
+            <dt>USD Liquidity</dt>
+            <dd>{{ format_currency(bitmine.usd_liquidity) }}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="card">
+        <h2>Arbitrage Watch</h2>
+        <p class="arbitrage-status">{{ arbitrage.status }}</p>
+        <p>{{ arbitrage.description }}</p>
+        <p class="spread">Spread vs. internal benchmark: {{ format_currency(arbitrage.spread) }}</p>
+      </section>
+
+      <section class="card">
+        <h2>Conviction Score</h2>
+        <div class="score" aria-label="True believer score">{{ believer.score }}/5</div>
+        <p>{{ believer.rationale }}</p>
+        <p>{{ believer.commentary }}</p>
+      </section>
+
+      <section class="card">
+        <h2>Strategy Notes</h2>
+        <p>{{ bitmine.strategic_notes }}</p>
+        <p class="meta">Updated alongside quarterly treasury disclosures.</p>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      <p>API Endpoint: <code>/api/bitmine</code></p>
+      <p class="meta">Data refreshes each time the page loads.</p>
+    </footer>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+requests==2.32.3


### PR DESCRIPTION
## Summary
- package the Flask dashboard inside a btc_monitor module so assets ship with the application
- add a python -m btc_monitor entry point and expose create_app/app for other runners
- refresh the README with cloning instructions and alternate server commands

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d96e729b90832c8766d1c94be25e12